### PR TITLE
Publish all release tags to Docker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,13 +11,11 @@ env:
 #       - master
 
 # Adding "git push origin <tag>" made it trigger the workflow twice.
-# Hence made it so that only pushing tags triggers the workflow.
-# And only if the tag is a version ending in ".0". 
-# Minor versions like "v2.40.1" will be skipped.
+# So, only pushing schema tags with 'v' prefix triggers workflow.
 on:
   push:
     tags:
-      - 'v*.0'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   buildx:


### PR DESCRIPTION
Currently, the latest Docker published release is v3.0.0, despite v3.0.1 having added a useful new feature (`--logout me`).

Ref https://hub.docker.com/r/matrixcommander/matrix-commander/tags (`latest` / `v3.0.0`) are latest, while https://github.com/8go/matrix-commander/tags shows v3.0.1 also.

I propose that this change will better ensure each tagged release be automatically submitted to Docker Hub also.